### PR TITLE
Try fix dropbox token problem Azure

### DIFF
--- a/server/auth/dropbox/passport.coffee
+++ b/server/auth/dropbox/passport.coffee
@@ -9,7 +9,11 @@ exports.setup = (User, config) ->
   , (accessToken, refreshToken, profile, done) ->
     User.findOne { provider: "dropbox", providerId: profile.id }, (err, user) ->
       return done err if err
-      return done err, user if user?
+
+      setTokenAndSave = =>
+        user.tokens.dropbox = accessToken
+        user.save() ; user
+      return done null, setTokenAndSave() if user?
 
       user = new User
         name: profile.displayName
@@ -22,5 +26,5 @@ exports.setup = (User, config) ->
           dropbox: accessToken
 
       user.save (err) ->
-        done err  if err
-        done err, user
+        done err if err
+        done null, user


### PR DESCRIPTION
La famosa pantalla blanca.

Activé una opción en Azure ("always on") que según leí es para que Azure haga alguna request cada tanto al servidor para que no lo ponga a dormir. Esto no incrementa el costo del site, solo viene desactivado porque en las versiones gratuitas no se puede activar, y dejandolo prendido hace que ande más rápido (y supongo que también contestará más rápido los "challenge" que manda Dropbox de forma random).

Al margen, ví que el 500 al loguearse ("token already used") aparecía cuando uno se logueaba en un lugar (ej: heroku, o localhost) y después en azure. Y encontré esto (leer mensaje del commit), que seguramente tenga mucho que ver.

@faloi 